### PR TITLE
Fix incorrect value being set on checkboxes

### DIFF
--- a/lunar_html/test_case.py
+++ b/lunar_html/test_case.py
@@ -248,7 +248,7 @@ class BaseLunarHTMLTestCase():
             elif field.tag in ['input', 'textarea']:
                 if field.attrib.get("type") == 'checkbox':
                     if field_value:
-                        results[field_name] = field_name
+                        results[field_name] = field_value
                     else:
                         pass
                 else:


### PR DESCRIPTION
Checkbox values should be set to their value, not their field name.
